### PR TITLE
Adding option to prevent browser default behaviour on recording key

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,15 @@ Mousetrap.record(function(sequence) {
     console.log('You pressed: ' + sequence.join(' '));
 }, 3000);
 ```
+
+You can also disable default browser behaviour while recording:
+
+```js
+// at initialize
+var Mousetrap = require('mousetrap-record')(require('mousetrap'), { timeout: 250, preventDefault: true });
+
+// or at record call
+Mousetrap.record(function(sequence) {
+    console.log('You pressed: ' + sequence.join(' '));
+}, 3000, true);
+```

--- a/mousetrap-record.js
+++ b/mousetrap-record.js
@@ -12,7 +12,8 @@ module.exports = function (Mousetrap, options) {
      * @type {Array}
      */
     var _config = Object.assign({
-        timeout: 1000
+        timeout: 1000,
+        preventDefault: false
     }, options);
 
     /**
@@ -64,7 +65,14 @@ module.exports = function (Mousetrap, options) {
          *
          * @type {number}
          */
-        _recordTimeout = _config.timeout;
+        _recordTimeout = _config.timeout,
+        
+        /**
+         * prevents firing browser events on recording key
+         * 
+         * @type {boolean}
+         */
+        _preventDefault = _config.preventDefault;
 
     /**
      * handles a character key event
@@ -80,6 +88,10 @@ module.exports = function (Mousetrap, options) {
         if (!self.recording) {
             _origHandleKey.apply(self, arguments);
             return;
+        }
+
+        if (_preventDefault) {
+            e.preventDefault();
         }
 
         // remember this character if we're currently recording a sequence
@@ -204,13 +216,15 @@ module.exports = function (Mousetrap, options) {
      * @param {Function} callback
      * @returns void
      */
-    Mousetrap.prototype.record = function(callback, timeout) {
+    Mousetrap.prototype.record = function(callback, timeout, preventDefault) {
         var self = this;
         self.recording = true;
 
         // if the user doesn't want to change the timeout
         // we still need to guarantee that it gets the default timeout
         _recordTimeout = timeout || _config.timeout;
+
+        _preventDefault = preventDefault || _config.preventDefault;
 
         _recordedSequenceCallback = function() {
             self.recording = false;


### PR DESCRIPTION
This pull request adds an option that allows the user to disable default browser hotkeys while recording.